### PR TITLE
Add environment settings and Makefile shortcuts

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,11 @@
+N8N_HOST=http://localhost:5678
+PLAYWRIGHT_HEADLESS=true
+
+# Chroma vektoritietokanta
+CHROMA_HOST=http://localhost:8000
+
+# Ollama LLM-palvelin
+OLLAMA_HOST=http://localhost:11434
+
+# Embedding-malli Ollamasta
+EMBED_MODEL=nomic-embed-text

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: up diag embed
+
+up:
+	docker compose down
+	docker compose up -d
+
+diag:
+	curl $$CHROMA_HOST/api/v1/heartbeat
+	curl $$OLLAMA_HOST/api/tags
+
+embed:
+	ollama pull $$EMBED_MODEL
+	python embed_to_chroma.py docs/example.pdf

--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
 # llmfixu
+
+## macOS Docker CLI path fix
+
+Docker Desktop may install the Docker CLI outside of your shell's `PATH`.
+If `docker` or `docker compose` commands are not found, run these steps:
+
+1. Ensure Docker Desktop is running.
+2. Create symlinks to the Docker binaries and reload your shell:
+
+   ```sh
+   which docker; docker --version || true
+
+   sudo mkdir -p /usr/local/bin ~/.docker/cli-plugins
+
+   sudo ln -sf "/Applications/Docker.app/Contents/Resources/bin/docker" \
+     /usr/local/bin/docker
+
+   sudo ln -sf "/Applications/Docker.app/Contents/Resources/cli-plugins/docker-compose" \
+     ~/.docker/cli-plugins/docker-compose
+
+   exec zsh -l
+
+   docker --version
+   docker compose version
+   ```
+3. Start services and run diagnostics:
+
+   ```sh
+   docker compose up -d
+   docker ps
+   make diag
+   ```
+
+   Ports 11434, 8000, 8080, and 5678 should be listening and curl tests should
+   succeed.
+
+4. Open in a browser:
+   - OpenWebUI: <http://127.0.0.1:8080>
+   - n8n: <http://127.0.0.1:5678>
+
+If `docker compose up -d` still fails, provide diagnostic output:
+
+```sh
+docker context ls
+docker info
+docker compose logs --no-log-prefix ollama
+```
+


### PR DESCRIPTION
## Summary
- define Chroma, Ollama, and embedding model settings in `.env`
- add Makefile shortcuts for starting services, testing endpoints, running embeddings, and diagnostics
- document macOS steps for exposing Docker CLI on PATH

## Testing
- `docker compose up -d` *(fails: command not found)*
- `docker ps` *(fails: command not found)*
- `export $(grep -v '^#' .env | xargs) && make diag` *(fails: couldn't connect to server)*
- `export $(grep -v '^#' .env | xargs) && make embed` *(fails: ollama: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c60ba45f088331b19ed1e3dc166db4