### PR TITLE
Add diagnostic Makefile

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,7 @@
+CHROMA_HOST=http://localhost:8000
+OLLAMA_HOST=http://localhost:11434
+EMBED_MODEL=nomic-embed-text
+OPENWEBUI_PORT=8080
+WEBUI_AUTH=true
+WEBUI_USERNAME=admin
+WEBUI_PASSWORD=admin123

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+diag:
+	@docker ps --format "table {{.Names}}	{{.Ports}}	{{.Status}}"
+	@curl -s http://127.0.0.1:11434/api/tags || true
+	@curl -s http://127.0.0.1:8000/api/v1/heartbeat || true
+	@curl -I http://127.0.0.1:8080 || true
+	@curl -I http://127.0.0.1:5678 || true


### PR DESCRIPTION
## Summary
- add a Makefile with a `diag` target to check Docker services and ports
- include default `.env` variables for service hosts and auth

## Testing
- `docker compose down -v` *(fails: command not found)*
- `docker compose pull` *(fails: command not found)*
- `docker compose up -d` *(fails: command not found)*
- `docker ps --format "table {{.Names}}\t{{.Ports}}\t{{.Status}}"` *(fails: command not found)*
- `curl -s http://127.0.0.1:11434/api/tags` *(no response)*
- `curl -s http://127.0.0.1:8000/api/v1/heartbeat` *(no response)*
- `curl -I http://127.0.0.1:8080` *(fails: couldn't connect to server)*
- `curl -I http://127.0.0.1:5678` *(fails: couldn't connect to server)*
- `make diag` *(fails: docker: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c61f0626ec83319624fd60484169a7